### PR TITLE
#163944000 Allow only users with verified emails to log in

### DIFF
--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -133,7 +133,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         """ Generates a token that expires in 24hrs """
         time = datetime.now() + timedelta(hours=24)
         token = jwt.encode({
-            "eamil": self.email,
+            "email": self.email,
             "username": self.username,
             "exp": int(time.strftime('%s'))
         }, settings.SECRET_KEY, algorithm='HS256')

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -172,7 +172,10 @@ class LoginSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 'A user with this email and password was not found.'
             )
-
+        if not user.is_verified:
+            raise serializers.ValidationError(
+                'Verify email before logging in.'
+            )
         # Django provides a flag on our `User` model called `is_active`. The
         # purpose of this flag to tell us whether the user has been banned
         # or otherwise deactivated. This will almost never be the case, but

--- a/authors/apps/authentication/tests/base_test.py
+++ b/authors/apps/authentication/tests/base_test.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.conf import settings
 from rest_framework.test import APITestCase
 import os
+from ..models import User
 
 
 class BaseTest(APITestCase):
@@ -17,6 +18,13 @@ class BaseTest(APITestCase):
         self.signup_url = reverse('authentication:user_signup')
         self.user_url = reverse('authentication:user_url')
         self.password_reset_url = reverse('authentication:reset_password')
+        self.auth_user_data = {
+            "user": {
+                "email": "pherndegz@gmail.com",
+                "password": "Jsn23$$nd",
+                "username": "PaulGichuki"
+            }
+        }
         self.user_data = {
             "user": {
                 "username": "James",
@@ -175,9 +183,9 @@ class BaseTest(APITestCase):
         }
 
         self.oauth2_data = {
-                    "client_provider": "facebook",
-                    "access_token": self.oauth2_token
-                }
+            "client_provider": "facebook",
+            "access_token": self.oauth2_token
+        }
 
         self.empty_token = {
             "client_provider": "facebook"
@@ -212,15 +220,31 @@ class BaseTest(APITestCase):
                                 user_details,
                                 format='json')
 
+    def authenticate_user(self):
+        """Invoke the server by sending a post request to the signup url."""
+
+        self.client.post(self.signup_url,
+                         self.auth_user_data,
+                         format='json')
+        user = User.objects.get(email=self.auth_user_data['user']['email'])
+        user.is_verified = True
+        user.save()
+        response = self.client.post(self.login_url,
+                                    self.auth_user_data,
+                                    format='json')
+        return response
+
     def send_reset_password_email(self, user_details):
-        """Invoke the server by sending a post request to the password reset url."""
+        """Invoke the server by sending a post request to the password reset 
+        url."""
         return self.client.post(self.password_reset_url,
                                 user_details,
                                 format='json')
 
     @staticmethod
     def create_url():
-        """Create a url with the token, to redirect the user to password update."""
+        """Create a url with the token, to redirect the user to password 
+        update."""
         token = jwt.encode({"email": "wearethephoenix34@gmail.com",
                             "iat": datetime.now(),
                             "exp": datetime.utcnow() + timedelta(minutes=5)},

--- a/authors/apps/authentication/tests/test_auth.py
+++ b/authors/apps/authentication/tests/test_auth.py
@@ -8,22 +8,22 @@ class TestGetUser(BaseTest):
     """Test for the login functionality of the app."""
 
     def test_get_users(self):
-        token = self.signup_a_user(self.user_data).data["user_info"]["token"]
+        token = self.authenticate_user().data["token"]
         response = self.client.get(self.user_url,
                                    HTTP_AUTHORIZATION=f'token {token}'
                                    )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["email"], "wearethephoenix34@gmail.com")
+        self.assertEqual(response.data["email"], "pherndegz@gmail.com")
 
     def test_wrong_token_header(self):
-        token = self.signup_a_user(self.user_data).data["user_info"]["token"]
+        token = self.authenticate_user().data["token"]
         response = self.client.get(self.user_url,
                                    HTTP_AUTHORIZATION=f'token{token}'
                                    )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_too_many_arguments_in_header(self):
-        token = self.signup_a_user(self.user_data).data["user_info"]["token"]
+        token = self.authenticate_user().data["token"]
         response = self.client.get(self.user_url,
                                    HTTP_AUTHORIZATION=f'token dd {token}'
                                    )

--- a/authors/apps/authentication/tests/test_login.py
+++ b/authors/apps/authentication/tests/test_login.py
@@ -53,3 +53,14 @@ class TestLogin(BaseTest):
                 "This field may not be blank."]
         )
         self.assertNotIn("token", response.data)
+    
+    def test_login_with_unverified_email(self):
+        """Test for a login with an unverified email"""
+        self.signup_a_user(self.user_data)
+        response = self.login_a_user(self.user_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["errors"]['error'], [
+                "Verify email before logging in."]
+        )
+        self.assertNotIn("token", response.data)

--- a/authors/apps/authentication/tests/test_login.py
+++ b/authors/apps/authentication/tests/test_login.py
@@ -9,10 +9,9 @@ class TestLogin(BaseTest):
 
     def test_successful_user_login(self):
         """Test for a successful user login."""
-        self.signup_a_user(self.user_data)
-        response = self.login_a_user(self.user_login_data)
+        response = self.authenticate_user()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["email"], "wearethephoenix34@gmail.com")
+        self.assertEqual(response.data["email"], "pherndegz@gmail.com")
         self.assertIn("token", response.data)
 
     def test_wrong_email_login(self):

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -72,9 +72,7 @@ class RegistrationAPIView(APIView):
 
         serializer.save()
         message = {
-            "message": "User successfully created. Check email for verification link",
-            "user_info": serializer.data,
-            "token": token
+            "message": "User successfully created. Check email for verification link"
         }
 
         return Response(message, status=status.HTTP_201_CREATED)
@@ -107,7 +105,7 @@ class VerifyAPIView(APIView):
 
         except Exception:
             message = {
-                'error': 'Verification email is not valid. Try again'
+                'error': 'Verification token is not valid. Try again'
             }
             return Response(message, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
**What does this PR do?**
Fixes bug in authentication feature to only allow users with verified emails to login

**Description of tasks to be completed**
- Remove authorization token from signup response
- Only allow users with verified emails to login
- Refactor all test modules

**What are the relevant Pivotal Tracker Stories?**
#163944000